### PR TITLE
Return a valid datetime obj. for datestamp instead of a string

### DIFF
--- a/pynmea2/nmea_utils.py
+++ b/pynmea2/nmea_utils.py
@@ -9,6 +9,15 @@ def timestamp(s):
         minute=int(s[2:4]),
         second=int(s[4:6]))
 
+
+def datestamp(s):
+    '''
+    Converts a datestamp given in "DDMMYY" ASCII format to a
+    datetime.datetime object
+    '''
+    return datetime.datetime.strptime(s, '%d%m%y')
+
+
 import re
 def dm_to_sd(dm):
     '''

--- a/pynmea2/types.py
+++ b/pynmea2/types.py
@@ -357,7 +357,7 @@ class RMC(NMEASentence, LatLonFix):
         ("Longitude Direction", "lon_dir"),
         ("Speed Over Ground", "spd_over_grnd", float),
         ("True Course", "true_course", float),
-        ("Datestamp", "datestamp"),
+        ("Datestamp", "datestamp", datestamp),
         ("Magnetic Variation", "mag_variation"),
         ("Magnetic Variation Direction", "mag_var_dir")
     )


### PR DESCRIPTION
Simple fix, just converting the datestamp to a valid datetime obj. instead of returning a string.
