### PR TITLE
Sentence types

### DIFF
--- a/test/test_types.py
+++ b/test/test_types.py
@@ -96,16 +96,17 @@ from pynmea2 import nmea
 
 
 def test_proprietary():
-    class ABC(nmea.ProprietarySentence):
+    class ABCX(nmea.ProprietarySentence):
         fields = (
             ('First', 'a'),
             ('Second', 'b'),
         )
 
-    data = '$PABC,1,2*13'
+    data = '$PABCX,1,2*4B'
     msg = pynmea2.parse(data)
-    assert isinstance(msg, ABC)
+    assert isinstance(msg, ABCX)
     assert msg.manufacturer == 'ABC'
+    assert msg.sentence_type =='X'
     assert msg.a == '1'
     assert msg.b == '2'
     assert str(msg)== data


### PR DESCRIPTION
Reordered proprietary match before talker because talker sentence and proprietary sentence type specifier can potentially conflict; however, possible talker (i.e.: GP, GN, GL etc..) should not have a first character P. Giving first priority to proprietary should give messages such as PABCX a match to manufacturer "ABC" and sentence "X" verses an incorrect match to talker "PA" and sentence "BCX". Specific verification of talker ids verses a known/expected list would be more optimal and safe. See http://www.catb.org/gpsd/NMEA.html for list of talker ids.
