### PR TITLE
Add configurable "stream_size" option.

### DIFF
--- a/pynmea2/stream.py
+++ b/pynmea2/stream.py
@@ -5,18 +5,15 @@ class NMEAStreamReader(object):
     '''
     Reads NMEA sentences from a stream.
     '''
-    def __init__(self, stream=None, stream_size=-1):
+    def __init__(self, stream=None):
         '''
         Create NMEAStreamReader object.
 
         `stream`: file-like object to read from, can be omitted to
         pass data to `next` manually
-        `stream_size`: determines # of bytes to read from stream for each
-        `next` user configurable to help responsiveness of stream reader
         '''
         self.stream = stream
         self.buffer = ''
-        self.stream_size = stream_size
 
     def next(self, data=None):
         '''
@@ -26,7 +23,7 @@ class NMEAStreamReader(object):
         '''
         if data is None:
             if self.stream:
-                data = self.stream.read(self.stream_size)
+                data = self.stream.readline()
             else:
                 return []
 

--- a/test/test_stream.py
+++ b/test/test_stream.py
@@ -22,20 +22,8 @@ def test_stream():
     assert sr.next() == []
 
     f = StringIO(data * 2)
-    #Test full file read
+    #Test line read
     sr = pynmea2.NMEAStreamReader(f)
-    assert len(sr.next()) == 2
-    assert len(sr.next()) == 0
-    #Test individual line read
-    f.seek(0)
-    sr = pynmea2.NMEAStreamReader(f,len(data))
-    assert len(sr.next()) == 1
-    assert len(sr.next()) == 1
-    assert len(sr.next()) == 0
-    #Test stream_size too small
-    f.seek(0)
-    sr = pynmea2.NMEAStreamReader(f,len(data)-1)
-    assert len(sr.next()) == 0
     assert len(sr.next()) == 1
     assert len(sr.next()) == 1
     assert len(sr.next()) == 0


### PR DESCRIPTION
This should give the user options to tune how responsive the stream reader is. For reading from file, a normal read is most optimal, but depending on what sentences are expected on a text string( i.e.: pyserial, tcp/ip socket) stream_size can be set appropriately. 

As expected for a stream_size smaller than a sentence, multiple next may need to be called to read in a full nmea_sentence.
