### PR TITLE
unify the data validity field names

### DIFF
--- a/pynmea2/types/talker.py
+++ b/pynmea2/types/talker.py
@@ -199,7 +199,7 @@ class GLL(TalkerSentence, LatLonFix):
         ('Longitude', 'lon'),
         ('Longitude Direction', 'lon_dir'),
         ('Timestamp', 'timestamp', timestamp),
-        ('Data Validity', "data_valid"),
+        ('Data Validity', "data_validity"),
         ("FAA mode indicator", "faa_mode"),
     )
 
@@ -308,7 +308,7 @@ class RMB(TalkerSentence):
     """ Recommended Minimum Navigation Information
     """
     fields = (
-        ("Data Validity", "validity"),
+        ("Data Validity", "data_validity"),
         ("Cross Track Error", "cross_track_error"), # nautical miles, 9.9 max
         ("Cross Track Error, direction to corrent", "cte_correction_dir"),
         ("Origin Waypoint ID", "origin_waypoint_id"),


### PR DESCRIPTION
There exists a discrepancy between the field names, illustrated below. This diff normalizes the validity fields to use 'data_validity', which is consistent with the format used in Dual Ground/Water Speed

>>> print msg.fields
(('Latitude', 'lat'), ('Latitude Direction', 'lat_dir'), ('Longitude', 'lon'), ('Longitude Direction', 'lon_dir'), ('Timestamp', 'timestamp', <function timestamp at 0x10f255230>), ('Data Validity', 'data_valid'), ('FAA mode indicator', 'faa_mode'))
>>> print msg.data_valid
A
>>> print msg.sentence_type
GLL

...
>>> print msg.fields
(('Timestamp', 'timestamp', <function timestamp at 0x10f255230>), ('Data Validity', 'data_validity'), ('Latitude', 'lat'), ('Latitude Direction', 'lat_dir'), ('Longitude', 'lon'), ('Longitude Direction', 'lon_dir'), ('Speed Over Ground', 'spd_over_grnd', <type 'float'>), ('True Course', 'true_course', <type 'float'>), ('Datestamp', 'datestamp', <function datestamp at 0x10f2552a8>), ('Magnetic Variation', 'mag_variation'), ('Magnetic Variation Direction', 'mag_var_dir'))
>>> print msg.data_validity
A
>>> print msg.sentence_type
RMC
