### PR TITLE
Fix sentence parser regex

### DIFF
--- a/pynmea2/nmea.py
+++ b/pynmea2/nmea.py
@@ -73,7 +73,7 @@ class NMEASentence(NMEASentenceBase):
         (?:[*](?P<checksum>[A-F0-9]{2}))?
 
         # optional trailing whitespace
-        \s*[\\\r\\\n]*$
+        \s*[\r\n]*$
         ''', re.X | re.IGNORECASE)
 
     talker_re = \


### PR DESCRIPTION
Fixed parser regex to match only `\r` and `\n` chars at end of line. Previously matched also `\`, which was wrong.