### PR TITLE
Fixed indexes for GRM __init__, added __init__ for SRF, added tests - issue #46

### DIFF
--- a/pynmea2/types/proprietary/grm.py
+++ b/pynmea2/types/proprietary/grm.py
@@ -4,14 +4,16 @@ from ... import nmea
 
 class GRM(nmea.ProprietarySentence):
     sentence_types = {}
+
     def __new__(_cls, manufacturer, data):
         name = manufacturer + data[0]
         cls = _cls.sentence_types.get(name, _cls)
         return super(GRM, cls).__new__(cls)
 
     def __init__(self, manufacturer, data):
-        self.sentence_type = manufacturer + data[1]
-        super(GRM, self).__init__(manufacturer, data[2:])
+        self.sentence_type = manufacturer + data[0]
+        super(GRM, self).__init__(manufacturer, data[1:])
+
 
 class GRME(GRM):
     """ GARMIN Estimated position error

--- a/pynmea2/types/proprietary/grm.py
+++ b/pynmea2/types/proprietary/grm.py
@@ -1,5 +1,7 @@
 # Garmin
 
+from decimal import Decimal
+
 from ... import nmea
 
 class GRM(nmea.ProprietarySentence):
@@ -19,11 +21,11 @@ class GRME(GRM):
     """ GARMIN Estimated position error
     """
     fields = (
-        ("Estimated Horiz. Position Error", "hpe"),
+        ("Estimated Horiz. Position Error", "hpe", Decimal),
         ("Estimated Horiz. Position Error Unit (M)", "hpe_unit"),
-        ("Estimated Vert. Position Error", "vpe"),
+        ("Estimated Vert. Position Error", "vpe", Decimal),
         ("Estimated Vert. Position Error Unit (M)", "vpe_unit"),
-        ("Estimated Horiz. Position Error", "osepe"),
+        ("Estimated Horiz. Position Error", "osepe", Decimal),
         ("Overall Spherical Equiv. Position Error", "osepe_unit")
     )
 

--- a/pynmea2/types/proprietary/srf.py
+++ b/pynmea2/types/proprietary/srf.py
@@ -5,10 +5,15 @@ from ... import nmea
 
 class SRF(nmea.ProprietarySentence):
     sentence_types = {}
+
     def __new__(_cls, manufacturer, data):
         name = manufacturer + data[0]
         cls = _cls.sentence_types.get(name, _cls)
         return super(SRF, cls).__new__(cls)
+
+    def __init__(self, manufacturer, data):
+        self.sentence_type = manufacturer + data[0]
+        super(SRF, self).__init__(manufacturer, data[1:])
 
 
 class SRF103(SRF):

--- a/test/test_proprietary.py
+++ b/test/test_proprietary.py
@@ -94,6 +94,12 @@ def test_srf():
     data = '$PSRF100,0,1200,8,1,1'
     msg = pynmea2.parse(data)
     assert type(msg) == pynmea2.srf.SRF100
+    assert msg.sentence_type == 'SRF100'
+    assert msg.protocol == '0'
+    assert msg.baud == '1200'
+    assert msg.databits == '8'
+    assert msg.stopbits == '1'
+    assert msg.parity == '1'
 
     # unimplemented sentence
     data = '$PSRF999,0,1200,8,1,1'
@@ -105,6 +111,13 @@ def test_grm():
     data = ' $PGRME,15.0,M,45.0,M,25.0,M*1C'
     msg = pynmea2.parse(data)
     assert type(msg) == pynmea2.grm.GRME
+    assert msg.sentence_type == 'GRME'
+    assert msg.hpe == 15.0
+    assert msg.hpe_unit == 'M'
+    assert msg.vpe == 45.0
+    assert msg.vpe_unit == 'M'
+    assert msg.osepe == 25.0
+    assert msg.osepe_unit == 'M'
 
 def test_tnl():
     data = '$PTNL,BPQ,224445.06,021207,3723.09383914,N,12200.32620132,W,EHT-5.923,M,5*60'


### PR DESCRIPTION
Per issue #46, I fixed the indexes in the __init__ function, duplicated the __init__ function for SRF types, and added some tests to make sure these work OK. I also made the Garmin position error values Decimals.