### PR TITLE
Issue #46 - Proper parsing of GRM and SRF messages

### DIFF
--- a/pynmea2/types/proprietary/grm.py
+++ b/pynmea2/types/proprietary/grm.py
@@ -14,13 +14,14 @@ class GRM(nmea.ProprietarySentence):
 
     def __init__(self, manufacturer, data):
         self.sentence_type = manufacturer + data[0]
-        super(GRM, self).__init__(manufacturer, data[1:])
+        super(GRM, self).__init__(manufacturer, data)
 
 
 class GRME(GRM):
     """ GARMIN Estimated position error
     """
     fields = (
+        ("Subtype", "subtype"),
         ("Estimated Horiz. Position Error", "hpe", Decimal),
         ("Estimated Horiz. Position Error Unit (M)", "hpe_unit"),
         ("Estimated Vert. Position Error", "vpe", Decimal),
@@ -34,6 +35,7 @@ class GRMM(GRM):
     """ GARMIN Map Datum
     """
     fields = (
+        ("Subtype", "subtype"),
         ('Currently Active Datum', 'datum'),
     )
 
@@ -42,6 +44,7 @@ class GRMZ(GRM):
     """ GARMIN Altitude Information
     """
     fields = (
+        ("Subtype", "subtype"),
         ("Altitude", "altitude"),
         ("Altitude Units (Feet)", "altitude_unit"),
         ("Positional Fix Dimension (2=user, 3=GPS)", "pos_fix_dim")

--- a/pynmea2/types/proprietary/grm.py
+++ b/pynmea2/types/proprietary/grm.py
@@ -4,14 +4,16 @@ from ... import nmea
 
 class GRM(nmea.ProprietarySentence):
     sentence_types = {}
+
     def __new__(_cls, manufacturer, data):
         name = manufacturer + data[0]
         cls = _cls.sentence_types.get(name, _cls)
         return super(GRM, cls).__new__(cls)
 
     def __init__(self, manufacturer, data):
-        self.sentence_type = manufacturer + data[1]
-        super(GRM, self).__init__(manufacturer, data[2:])
+        self.sentence_type = manufacturer + data[0]
+        super(GRM, self).__init__(manufacturer, data[1:])
+
 
 class GRME(GRM):
     """ GARMIN Estimated position error

--- a/pynmea2/types/proprietary/grm.py
+++ b/pynmea2/types/proprietary/grm.py
@@ -45,7 +45,7 @@ class GRMZ(GRM):
     """
     fields = (
         ("Subtype", "subtype"),
-        ("Altitude", "altitude"),
+        ("Altitude", "altitude", Decimal),
         ("Altitude Units (Feet)", "altitude_unit"),
         ("Positional Fix Dimension (2=user, 3=GPS)", "pos_fix_dim")
     )

--- a/pynmea2/types/proprietary/grm.py
+++ b/pynmea2/types/proprietary/grm.py
@@ -1,5 +1,7 @@
 # Garmin
 
+from decimal import Decimal
+
 from ... import nmea
 
 class GRM(nmea.ProprietarySentence):
@@ -19,11 +21,11 @@ class GRME(GRM):
     """ GARMIN Estimated position error
     """
     fields = (
-        ("Estimated Horiz. Position Error", "hpe"),
+        ("Estimated Horiz. Position Error", "hpe", Decimal),
         ("Estimated Horiz. Position Error Unit (M)", "hpe_unit"),
-        ("Estimated Vert. Position Error", "vpe"),
+        ("Estimated Vert. Position Error", "vpe", Decimal),
         ("Estimated Vert. Position Error Unit (M)", "vpe_unit"),
-        ("Estimated Horiz. Position Error", "osepe"),
+        ("Estimated Horiz. Position Error", "osepe", Decimal),
         ("Overall Spherical Equiv. Position Error", "osepe_unit")
     )
 

--- a/pynmea2/types/proprietary/srf.py
+++ b/pynmea2/types/proprietary/srf.py
@@ -13,11 +13,12 @@ class SRF(nmea.ProprietarySentence):
 
     def __init__(self, manufacturer, data):
         self.sentence_type = manufacturer + data[0]
-        super(SRF, self).__init__(manufacturer, data[1:])
+        super(SRF, self).__init__(manufacturer, data)
 
 
 class SRF103(SRF):
     fields = (
+        ("Subtype", "subtype"),
         ('Sentence type', 'sentence'),
         # 00=GGA
         # 01=GLL
@@ -36,6 +37,7 @@ class SRF103(SRF):
 
 class SRF100(SRF):
     fields = (
+        ("Subtype", "subtype"),
         ('Protocol', 'protocol'),
         # 0 = SiRF Binary
         # 1 = NMEA

--- a/pynmea2/types/proprietary/srf.py
+++ b/pynmea2/types/proprietary/srf.py
@@ -5,10 +5,15 @@ from ... import nmea
 
 class SRF(nmea.ProprietarySentence):
     sentence_types = {}
+
     def __new__(_cls, manufacturer, data):
         name = manufacturer + data[0]
         cls = _cls.sentence_types.get(name, _cls)
         return super(SRF, cls).__new__(cls)
+
+    def __init__(self, manufacturer, data):
+        self.sentence_type = manufacturer + data[0]
+        super(SRF, self).__init__(manufacturer, data[1:])
 
 
 class SRF103(SRF):

--- a/test/test_proprietary.py
+++ b/test/test_proprietary.py
@@ -94,6 +94,12 @@ def test_srf():
     data = '$PSRF100,0,1200,8,1,1'
     msg = pynmea2.parse(data)
     assert type(msg) == pynmea2.srf.SRF100
+    assert msg.sentence_type == 'SRF100'
+    assert msg.protocol == '0'
+    assert msg.baud == '1200'
+    assert msg.databits == '8'
+    assert msg.stopbits == '1'
+    assert msg.parity == '1'
 
     # unimplemented sentence
     data = '$PSRF999,0,1200,8,1,1'
@@ -105,6 +111,13 @@ def test_grm():
     data = ' $PGRME,15.0,M,45.0,M,25.0,M*1C'
     msg = pynmea2.parse(data)
     assert type(msg) == pynmea2.grm.GRME
+    assert msg.sentence_type == 'GRME'
+    assert msg.hpe == 15.0
+    assert msg.hpe_unit == 'M'
+    assert msg.vpe == 45.0
+    assert msg.vpe_unit == 'M'
+    assert msg.osepe == 25.0
+    assert msg.osepe_unit == 'M'
 
 def test_tnl():
     data = '$PTNL,BPQ,224445.06,021207,3723.09383914,N,12200.32620132,W,EHT-5.923,M,5*60'


### PR DESCRIPTION
It turned out that changing the data field as I had tried in the first place caused a test to fail. I decided it would be better to just add a "subtype" field as the first field for the GRM and SRF sentence types.

I added detail to the tests to make sure these sentence types are parsed correctly.

For the Garmin sentence types, I set the numeric fields to be Decimals.