### PR TITLE
Changed syntax for Python 2.6

### DIFF
--- a/pynmea2/nmea.py
+++ b/pynmea2/nmea.py
@@ -26,7 +26,7 @@ class NMEASentenceType(type):
         if base is object:
             return
         base.sentence_types[name] = cls
-        cls.name_to_idx = {f[1]:i for i, f in enumerate(cls.fields)}
+        cls.name_to_idx = dict((f[1], i) for i, f in enumerate(cls.fields))
 
 
 # http://mikewatkins.ca/2008/11/29/python-2-and-3-metaclasses/


### PR DESCRIPTION
Previous generator/comprehension syntax is incompatible with Python 2.6.  Changing this one line allowed the library to be imported and seems to work fine (examples in the README work, etc.).