### PR TITLE
Add support for SXN21,22,23,24 and test for 23

### DIFF
--- a/pynmea2/types/proprietary/sxn.py
+++ b/pynmea2/types/proprietary/sxn.py
@@ -59,3 +59,39 @@ class SXN20(SXN):
         ('Heading quality', 'head_qual', int),
         ('Roll and pitch quality', 'rp_qual', int),
     )
+
+
+class SXN21(SXN):
+    fields = (
+        ('Message Type', 'message_type', int),
+        ('Event code: 1 = system restart.', 'event', int),
+    )
+
+
+class SXN22(SXN):
+    fields = (
+        ('Message Type', 'message_type', int),
+        ('Gyro calibration value since system start-up in degrees', 'gyro_calib', float),
+        ('Short-term gyro offset in degrees', 'gyro_ffs', float),
+    )
+
+
+class SXN23(SXN):
+    fields = (
+        ('Message Type', 'message_type', int),
+        ('Roll in degrees. Positive with port side up.', 'roll', float),
+        ('Pitch in degrees. Positive with bow up.', 'pitch', float),
+        ('Heading, degrees true (0.00 - 359.99).', 'head', float),
+        ('Heave in metres. Positive down.', 'heave', float)
+    )
+
+
+class SXN24(SXN):
+    fields = (
+        ('Message Type', 'message_type', int),
+        ('Roll rate in degrees/second. Positive when port side is moving upwards.', 'roll_rate', float),
+        ('Pitch rate in degrees/second. Positive when bow is moving upwards.', 'pitch_rate', float),
+        ('Yaw rate in degrees/second. Positive when bow is moving towards starboard.', 'yaw_rate', float),
+        ('Vertical velocity in metres/second. Positive when moving downwards.', 'vertical_vel', float)
+    )
+

--- a/test/test_sxn.py
+++ b/test/test_sxn.py
@@ -1,5 +1,6 @@
 import pynmea2
 
+
 def test_sxn20():
     data = '$PSXN,20,0,0,0,0*3B'
     msg = pynmea2.parse(data)
@@ -9,3 +10,15 @@ def test_sxn20():
     assert msg.hgt_qual == 0
     assert msg.head_qual == 0
     assert msg.rp_qual == 0
+
+
+def test_sxn23():
+    data = '$PSXN,23,0.30,-0.97,298.57,0.13*1B'
+    msg = pynmea2.parse(data)
+    assert isinstance(msg, pynmea2.types.sxn.SXN23)
+    assert msg.message_type == 23
+    assert msg.roll == 0.30
+    assert msg.pitch == -0.97
+    assert msg.head == 298.57
+    assert msg.heave == 0.13
+


### PR DESCRIPTION
Add support for Seapath MRU Seatex proprietary messages.

Include test case for 23.  My device is currently only outputting 20 and 23, so I don't have real data to test the other messages at this time.