### PR TITLE
Add support for RT300 (?) PASHR attitude sentence.

### DIFF
--- a/pynmea2/types/proprietary/ash.py
+++ b/pynmea2/types/proprietary/ash.py
@@ -16,14 +16,40 @@ class ASH(nmea.ProprietarySentence):
         '''
             Return the correct sentence type based on the first field
         '''
-        sentence_type = data[1]
+        if len(data[1]) == 10:
+            sentence_type = 'ATT'
+        else:
+            sentence_type = data[1]
+
         name = manufacturer + 'R' + sentence_type
         cls = _cls.sentence_types.get(name, _cls)
         return super(ASH, cls).__new__(cls)
 
     def __init__(self, manufacturer, data):
-        self.sentence_type = data[1]
-        super(ASH, self).__init__(manufacturer, data[2:])
+        if len(data[1]) == 10:
+            self.sentence_type = 'ATT'
+            super(ASH, self).__init__(manufacturer, data[1:])
+        else:
+            self.sentence_type = data[1]
+            super(ASH, self).__init__(manufacturer, data[2:])
+
+class ASHRATT(ASH):
+    """
+        RT300 proprietary attitude sentence
+    """
+    fields = (
+        ('Timestamp', 'timestamp', timestamp),
+        ('Heading Angle', 'true_heading', float),
+        ('Is True Heading', 'is_true_heading'),
+        ('Roll Angle', 'roll', float),
+        ('Pitch Angle', 'pitch', float),
+        ('Heave', 'heading', float),
+        ('Roll Accuracy Estimate', 'roll_accuracy', float),
+        ('Pitch Accuracy Estimate', 'pitch_accuracy', float),
+        ('Heading Accuracy Estimate', 'heading_accuracy', float),
+        ('Aiding Status', 'aiding_status', Decimal),
+        ('IMU Status', 'imu_status', Decimal),
+    )
 
 class ASHRHPR(ASH):
     """

--- a/test/test_proprietary.py
+++ b/test/test_proprietary.py
@@ -126,6 +126,22 @@ def test_ash():
     assert msg.sentence_type == 'LTN'
     assert msg.latency == 3
 
+def test_pashr():
+    data = '$PASHR,130533.620,0.311,T,-80.467,-1.395,,0.066,0.067,0.215,2,3*0B'
+    msg = pynmea2.parse(data)
+    assert type(msg) == pynmea2.ash.ASHRATT
+    assert msg.timestamp == datetime.time(13, 05, 33, 620000)
+    assert msg.sentence_type == 'ATT'
+    assert msg.true_heading == 0.311
+    assert msg.is_true_heading == 'T'
+    assert msg.roll == -80.467
+    assert msg.pitch == -1.395
+    assert msg.roll_accuracy == 0.066
+    assert msg.pitch_accuracy == 0.067
+    assert msg.heading_accuracy == 0.215
+    assert msg.aiding_status == 2
+    assert msg.imu_status == 3
+
 def test_tnl():
     data = '$PTNL,BPQ,224445.06,021207,3723.09383914,N,12200.32620132,W,EHT-5.923,M,5*60'
     msg = pynmea2.parse(data)

--- a/test/test_proprietary.py
+++ b/test/test_proprietary.py
@@ -130,7 +130,7 @@ def test_pashr():
     data = '$PASHR,130533.620,0.311,T,-80.467,-1.395,,0.066,0.067,0.215,2,3*0B'
     msg = pynmea2.parse(data)
     assert type(msg) == pynmea2.ash.ASHRATT
-    assert msg.timestamp == datetime.time(13, 05, 33, 620000)
+    assert msg.timestamp == datetime.time(13, 5, 33, 620000)
     assert msg.sentence_type == 'ATT'
     assert msg.true_heading == 0.311
     assert msg.is_true_heading == 'T'


### PR DESCRIPTION
This specific sentence is being used by at least a few aviation GPS sensors, starting with Applanix POS AV series [1]

Note on the wild, because POS AV datasheets are hidden under registration-wall [2]:
> Field number:
hhmmss.sss - UTC time
hhh.hh - Heading in degrees
T - flag to indicate that the Heading is True Heading (i.e. to True North)
rrr.rr - Roll Angle in degrees
ppp.pp - Pitch Angle in degrees
xxx.xx - Heave
a.aaa - Roll Angle Accuracy Estimate (Stdev) in degrees
b.bbb - Pitch Angle Accuracy Estimate (Stdev) in degrees
c.ccc - Heading Angle Accuracy Estimate (Stdev) in degrees
d - Aiding Status
e - IMU Status
hh - Checksum

> [PASHR] describes this sentence as NMEA, though other sources say it is Ashtech proprietary and describe a different format.
Example:
$PASHR,085335.000,224.19,T,-01.26,+00.83,+00.00,0.101,0.113,0.267,1,0*06



[1]  https://www.applanix.com/products/posav.htm
[2] http://www.catb.org/gpsd/NMEA.html#_pashr_rt300_proprietary_roll_and_pitch_sentence

Maybe lack of sentence type identificator could have been solved a little bit nicer....