### PR TITLE
Add support for proprietary RDID sentence

### DIFF
--- a/pynmea2/types/proprietary/__init__.py
+++ b/pynmea2/types/proprietary/__init__.py
@@ -1,5 +1,6 @@
 from . import ash
 from . import grm
+from . import rdi
 from . import srf
 from . import sxn
 from . import tnl

--- a/pynmea2/types/proprietary/rdi.py
+++ b/pynmea2/types/proprietary/rdi.py
@@ -1,0 +1,25 @@
+""" Support for proprietary message(s) from RD Instruments
+"""
+
+from ... import nmea
+
+class RDI(nmea.ProprietarySentence):
+    """ RD Instruments message. Only one sentence known?
+    """
+    sentence_types = {}
+    def __new__(_cls, *_):
+        return super(RDI, RDID).__new__(RDID)
+
+class RDID(RDI):
+    """ RD Instruments heading, pitch and roll data
+    """
+    def __init__(self, manufacturer, data):
+        self.sentence_type = 'D'
+        # pylint: disable=bad-super-call
+        super(RDI, self).__init__(manufacturer, data[1:])
+
+    fields = (
+        ("Pitch", "pitch", float),
+        ("Roll", "roll", float),
+        ("Heading", "heading", float)
+    )

--- a/test/test_rdi.py
+++ b/test/test_rdi.py
@@ -1,0 +1,10 @@
+import pynmea2
+
+def test_rdid():
+    data = '$PRDID,-1.31,7.81,47.31*68'
+    msg = pynmea2.parse(data)
+    assert type(msg) == pynmea2.rdi.RDID
+    assert msg.sentence_type == 'D'
+    assert msg.pitch == -1.31
+    assert msg.roll == 7.81
+    assert msg.heading == 47.31


### PR DESCRIPTION
This is for RD Instruments proprietary attitude sentence. Again, not sure if I handled lack of other sentences from the same manufacturer correctly...

> $PRDID, PPP.PP, RRR.RR, xxx.xx*hh
> PPP.PP | Pitch | -90.00 to +90.00 | Degrees
> RRR.RR | Roll | -90.00 to +90.00 | Degrees
> xxx.xx | Sensor heading | 0 to 359.99 | Degrees
> *hh | Checksum 

Source:
- http://www.oceandatarat.org/?page_id=723
- http://pages.uoregon.edu/drt/MGL0910_sup/html_ref/formats/posmv.html
- http://www.comm-tec.com/Prods/mfgs/RDI/Software/Manuals/VMDAS-Manual/VmDas%20Users%20Guide.pdf

