### PR TITLE
NMEAStreamReader: support iterator protocol

### DIFF
--- a/pynmea2/stream.py
+++ b/pynmea2/stream.py
@@ -59,3 +59,15 @@ class NMEAStreamReader(object):
                     yield e
                 if self.errors == 'ignore':
                     pass
+
+    def __iter__(self):
+        '''
+        Support the iterator protocol.
+
+        This allows NMEAStreamReader object to be used in a for loop.
+
+          for batch in NMEAStreamReader(stream):
+              for msg in batch:
+                  print msg
+        '''
+        return self


### PR DESCRIPTION
This allows NMEAStreamReader object to be used in a for loop:

```python
for batch in NMEAStreamReader(stream):
    for msg in batch:
        print msg
```