### PR TITLE
NMEAStreamReader: support iterator protocol

### DIFF
--- a/pynmea2/stream.py
+++ b/pynmea2/stream.py
@@ -60,6 +60,8 @@ class NMEAStreamReader(object):
                 if self.errors == 'ignore':
                     pass
 
+    __next__ = next
+
     def __iter__(self):
         '''
         Support the iterator protocol.

--- a/pynmea2/stream.py
+++ b/pynmea2/stream.py
@@ -59,3 +59,15 @@ class NMEAStreamReader(object):
                     yield e
                 if self.errors == 'ignore':
                     pass
+
+    def __iter__(self):
+        '''
+        Support the iterator protocol.
+
+        This allows NMEAStreamReader object to be used in a for loop.
+
+          for batch in NMEAStreamReader(stream):
+              for msg in batch:
+                  print msg
+        '''
+        return self

--- a/test/test_stream.py
+++ b/test/test_stream.py
@@ -30,6 +30,7 @@ def test_stream():
     assert len(list(sr.next())) == 1
     assert len(list(sr.next())) == 0
 
+
 def test_iter():
     sr = pynmea2.NMEAStreamReader(StringIO(DATA))
     for batch in sr:
@@ -37,6 +38,7 @@ def test_iter():
             assert isinstance(msg, pynmea2.GGA)
             break
         break
+
 
 def test_raise_errors():
     sr = pynmea2.NMEAStreamReader(errors='raise')

--- a/test/test_stream.py
+++ b/test/test_stream.py
@@ -30,6 +30,13 @@ def test_stream():
     assert len(list(sr.next())) == 1
     assert len(list(sr.next())) == 0
 
+def test_iter():
+    sr = pynmea2.NMEAStreamReader(StringIO(DATA))
+    for batch in sr:
+        for msg in batch:
+            assert isinstance(msg, pynmea2.GGA)
+            break
+        break
 
 def test_raise_errors():
     sr = pynmea2.NMEAStreamReader(errors='raise')


### PR DESCRIPTION
This allows NMEAStreamReader object to be used in a for loop:

```python
for batch in NMEAStreamReader(stream):
    for msg in batch:
        print msg
```

With additional support for Python 3 not contemplated in #81.

Didn't add a test because the first `for` always waits for more data in the stream.