### PR TITLE
New sentences: ALR and HBT

### DIFF
--- a/pynmea2/nmea_utils.py
+++ b/pynmea2/nmea_utils.py
@@ -25,6 +25,17 @@ def datestamp(s):
     return datetime.datetime.strptime(s, '%d%m%y').date()
 
 
+def alr_boolean(s):
+    if s == 'A':
+        return True
+    elif s == 'V':
+        return False
+    else:
+        raise ValueError(
+            'Invalid boolean for ALR sentence: {}. '
+            'Valid values are ("A", "V").'.format(repr(s)))
+
+
 import re
 def dm_to_sd(dm):
     '''

--- a/pynmea2/types/talker.py
+++ b/pynmea2/types/talker.py
@@ -281,6 +281,16 @@ class GSV(TalkerSentence):
     )  # 00-99 dB
 
 
+class HBT(TalkerSentence):
+    '''Heartbeat supervision sentence
+    '''
+    fields = (
+        ('Configured repeat interval', 'repeat_interval', float),
+        ('Equipment status', 'status'),
+        ('Sequential sentence identifier', 'sequential_sentence_id', int),
+    )
+
+
 class HDG(TalkerSentence):
     """ NMEA 0183 standard Heading, Deviation and Variation
         Format: $HCHDG,<1>,<2>,<3>,<4>,<5>*hh<CR><LF>

--- a/pynmea2/types/talker.py
+++ b/pynmea2/types/talker.py
@@ -43,6 +43,24 @@ class ALM(TalkerSentence):
     )
 
 
+class ALR(TalkerSentence):
+    ''' Set alarm state
+    '''
+    fields = (
+        ('Time of alarm condition change', 'timestamp', timestamp),
+        ('Unique alarm number (identifier) at alarm source', 'alarm_id'),
+        (
+            'Alarm condition (A=threshold exceeded, V=not exceeded)',
+            'threshold_exceeded', alr_boolean
+        ),
+        (
+            'Alarm acknowledge state (A=acknowledged, V=unacknowledged)',
+            'acknowledged', alr_boolean
+        ),
+        ('Alarm\'s description text', 'description'),
+    )
+
+
 class APA(TalkerSentence):
     """ Autopilot Sentence "A"
     """

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -256,3 +256,30 @@ def test_ALR(data, fields):
 )
 def test_ALR_invalid_boolean(data):
     msg = pynmea2.parse(data)
+
+@pytest.mark.parametrize('data, fields',
+    [
+        (
+            '$GPHBT,50,A,0*11',
+            dict(
+                repeat_interval=50,
+                status='A',
+                sequential_sentence_id=0,
+            )
+        ),
+        (
+            '$GPHBT,11,k,1*3F',
+            dict(
+                repeat_interval=11,
+                status='k',
+                sequential_sentence_id=1,
+            ),
+        ),
+    ]
+)
+def test_HBT(data, fields):
+    msg = pynmea2.parse(data)
+    assert msg.render() == data
+    if not fields is None:
+        for name, value in fields.items():
+            assert getattr(msg, name) == value

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -220,3 +220,39 @@ def test_STALK_unidentified_command():
     assert msg.render() == data
     assert msg.command_name == 'Unknown Command'
 
+@pytest.mark.parametrize('data, fields',
+    [
+        ('$GPALR,,,V,V,*64', None),
+        ('$GPALR,193425.01,,A,V,*54', None),
+        ('$GPALR,193425,,V,A,*7B', None),
+        (
+            '$GPALR,193425.01,ALARM 42,V,V,Meaning of life found*28',
+            dict(
+                timestamp=datetime.time(
+                    hour=int(19),
+                    minute=int(34),
+                    second=int(25),
+                    microsecond=10000),
+                alarm_id='ALARM 42',
+                threshold_exceeded=False,
+                acknowledged=False,
+                description='Meaning of life found',
+            ),
+        ),
+    ])
+def test_ALR(data, fields):
+    msg = pynmea2.parse(data)
+    assert msg.render() == data
+    if not fields is None:
+        for name, value in fields.items():
+            assert getattr(msg, name) == value
+
+@pytest.mark.parametrize('data',
+    [
+        '$GPALR,,,k,V,*59',
+        '$GPALR,,,V,x,*4A',
+        '$GPALR,,,A,1,*14',
+    ]
+)
+def test_ALR_invalid_boolean(data):
+    msg = pynmea2.parse(data)


### PR DESCRIPTION
While reading NMEA data, I've encountered three sentences not implemented in pynmea2: ALR (Set alarm state), HBT (heartbeat) and POS (Device position and ship dimensions). These appear to be part of version 4.10 of the NMEA standard. 

I've found docs for the first two and implemented them. If anyone knows the syntax of the POS sentence and can share that with me, I might be able to implement that too.