### PR TITLE
Proprietary extensions for Vectronix Moskito TI laser measurement device

### DIFF
--- a/pynmea2/types/proprietary/__init__.py
+++ b/pynmea2/types/proprietary/__init__.py
@@ -5,4 +5,5 @@ from . import srf
 from . import sxn
 from . import tnl
 from . import ubx
+from . import vtx
 

--- a/pynmea2/types/proprietary/vtx.py
+++ b/pynmea2/types/proprietary/vtx.py
@@ -1,0 +1,84 @@
+# Vectronix Moskito TI (LRF)
+
+from decimal import Decimal
+
+from ... import nmea
+from ...nmea_utils import *
+
+class VTX(nmea.ProprietarySentence):
+    sentence_types = {}
+
+    def __new__(_cls, manufacturer, data):
+        name = manufacturer + data[1]
+        cls = _cls.sentence_types.get(name, _cls)
+        return super(VTX, cls).__new__(cls)
+
+    def __init__(self, manufacturer, data):
+        self.sentence_type = manufacturer + data[0]
+        super(VTX, self).__init__(manufacturer, data)
+
+
+class VTX0002(VTX):
+    """ Vectronix measurement: laser distance and angles (degrees) with declination
+    """
+    fields = (
+        ("Message Placeholder", "mplaceholder"),
+        ("Subtype", "subtype"),
+        ("Measurement ID", "measurement_id", int),
+        ("Distance (meters)", "dist", float),
+        ("Distance unit", "dist_unit"),
+        ("Direction (degrees)", "direction", float),
+        ("Direction unit", "direction_unit"),
+        ("Vertical angle (degrees)", "va", float),
+        ("Magnetic declination (degrees)", "decl", float),
+        ("Magnetic declination ref (E/W)", "decl_ref")
+    )
+
+
+class VTX0000(VTX):
+    """ Vectronix raw measurement: laser distance and angles (radians) without declination
+    """
+    fields = (
+        ("Message Placeholder", "mplaceholder"),
+        ("Subtype", "subtype"),
+        ("Distance (meters)", "dist", float),
+        ("Distance unit", "dist_unit"),
+        ("Direction (radians)", "direction", float),
+        ("Roll angle (radians)", "roll", float),
+        ("Vertical angle (radians)", "va", float),
+        ("Angular units type", "angle_units")
+    )
+
+
+class VTX0020(VTX, LatLonFix):
+    """ Vectronix self location: lat, long, altitude
+    """
+    fields = (
+        ("Message Placeholder", "mplaceholder"),
+        ("Subtype", "subtype"),
+        ("Measurement ID", "measurement_id", int),
+        ('Latitude', 'lat'),
+        ('Latitude Direction', 'lat_dir'),
+        ('Longitude', 'lon'),
+        ('Longitude Direction', 'lon_dir'),
+        ('Altitude above WGS84 ellipsoid, meters', 'altitude', float),
+        ('Altitude units', 'altitude_units')
+    )
+
+
+class VTX0012(VTX, LatLonFix):
+    """ Vectronix target location: lat, long, altitude, gain
+    """
+    fields = (
+        ("Message Placeholder", "mplaceholder"),
+        ("Subtype", "subtype"),
+        ("Measurement ID", "measurement_id", int),
+        ('Latitude', 'lat'),
+        ('Latitude Direction', 'lat_dir'),
+        ('Longitude', 'lon'),
+        ('Longitude Direction', 'lon_dir'),
+        ('Altitude above WGS84 ellipsoid, meters', 'altitude', float),
+        ('Altitude units', 'altitude_units'),
+        ('Gain (meters)', 'gain', float),
+        ('Gain units', 'gain_units')
+    )

--- a/test/test_proprietary.py
+++ b/test/test_proprietary.py
@@ -171,3 +171,27 @@ def test_unknown_sentence():
     assert msg.manufacturer == 'ZZZ'
     assert msg.data == ['ABC', '1', '2', '3']
     assert msg.render(checksum=False, dollar=False) == data
+
+
+def test_proprietary_VTX_0002():
+    # A sample proprietary sentence from a Vectronix device (laser distance)
+    data = "$PVTX,0002,181330,00005.22,M,262.518,T,-01.967,09.358,W*7E"
+    msg = pynmea2.parse(data)
+    assert msg.manufacturer == 'VTX'
+    assert msg.dist == 5.22
+    assert msg.direction == 262.518
+    assert msg.va == -1.967
+    assert msg.render() == data
+
+
+def test_proprietary_VTX_0012():
+    # A sample proprietary sentence from a Vectronix device (target position)
+    data = "$PVTX,0012,177750,3348.5861,N,10048.5861,W,00045.2,M,038.8,M*22"
+    msg = pynmea2.parse(data)
+    assert msg.manufacturer == 'VTX'
+    assert msg.latitude == 33.80976833333333
+    assert msg.longitude == -100.80976833333334
+    assert msg.altitude == 45.2
+    assert msg.gain == 38.8
+    assert msg.render() == data
+


### PR DESCRIPTION
New NMEA sentences for a proprietary LRF