### PR TITLE
Add support for GlobalTop MTK (Work in progress)

### DIFF
--- a/pynmea2/types/proprietary/__init__.py
+++ b/pynmea2/types/proprietary/__init__.py
@@ -8,4 +8,4 @@ from . import sxn
 from . import tnl
 from . import ubx
 from . import vtx
-
+from . import mtk

--- a/pynmea2/types/proprietary/mtk.py
+++ b/pynmea2/types/proprietary/mtk.py
@@ -1,0 +1,107 @@
+# -- TRIMBLE -- #
+
+# pylint: disable=wildcard-import,unused-wildcard-import
+from ... import nmea
+from ...nmea_utils import *
+""" Support for proprietary messages from MediaTek recievers.
+    Documentation: https://cdn-shop.adafruit.com/datasheets/PMTK_A11.pdf
+"""
+
+
+class MTK(nmea.ProprietarySentence):
+    sentence_types = {}
+    """
+        Generic MTK Message
+    """
+    def __new__(_cls, manufacturer, data):
+        '''
+            Return the correct sentence type based on the first field
+        '''
+        sentence_type = data[0] or data[1]
+        name = manufacturer + sentence_type
+        cls = _cls.sentence_types.get(name, _cls)
+        return super(MTK, cls).__new__(cls)
+
+    def __init__(self, manufacturer, data):
+        self.sentence_type = data[0] or data[1]
+        super(MTK, self).__init__(manufacturer, data)
+
+
+class MTK001(MTK):
+    """
+        001 MTK_ACK
+    """
+    fields = (
+        ('Blank', '_'),
+        ('Cmd', 'cmd', int),
+        ('Flag', 'flag', int),
+    )
+
+
+class MTK010(MTK):
+    """
+        010 MTK_SYS_MSG
+    """
+    fields = (
+        ('Blank', '_'),
+        ('Data', 'data', int),  # 0 = UNKNOWN
+                                # 1 = STARTUP
+                                # 2 = Notification for host aiding EPO
+                                # 3 = Notification for transition to Normal mode success
+    )
+
+
+class MTK011(MTK):
+    """
+        011 MTK_TXT_MSG
+    """
+    fields = (
+        ('Blank', '_'),
+        ('Text', 'text'),
+    )
+
+
+class MTK101(MTK):
+    """
+        101 MTK_CMD_HOT_START
+    """
+    fields = (
+        ('Blank', '_'),
+    )
+
+
+class MTK102(MTK):
+    """
+        102 MTK_CMD_WARM_START
+    """
+    fields = ( 
+        ('Blank', '_'),
+    )
+
+
+class MTK103(MTK):
+    """
+        103 MTK_CMD_COLD_START
+    """
+    fields = (
+        ('Blank', '_'),
+    )
+
+
+class MTK104(MTK):
+    """
+        104 MTK_CMD_FULL_COLD_START
+    """
+    fields = (
+        ('Blank', '_'),
+    )
+
+
+class MTK220(MTK):
+    """
+        220 MTK_SET_NMEA_UPDATERATE
+    """
+    fields = (
+        ('Blank', '_'),
+        ("FixInterval", "fix_interval", int),  # Fix interval in milliseconds from 100 to 10,000
+    )

--- a/test/test_mtk.py
+++ b/test/test_mtk.py
@@ -1,0 +1,15 @@
+import pynmea2
+
+
+def test_mtk001():
+    data = '$PMTK001,604,3*32'
+    msg = pynmea2.parse(data)
+    assert isinstance(msg, pynmea2.types.mtk.MTK001)
+    assert msg.sentence_type == '001'
+    assert msg.cmd == 604
+    assert msg.flag == 3
+
+
+def test_mtk220():
+    sentence = pynmea2.ProprietarySentence('MTK', ('220', '200', ))
+    assert str(sentence) == '$PMTK220,200*2C'


### PR DESCRIPTION
I'm working with a PA1010D i2c GPS module on a breakout which implements some of the MTK messages documented here: https://cdn-shop.adafruit.com/datasheets/PMTK_A11.pdf

This PR- when finished- should add support for the full set of MTK messages.

So far it seems to be correctly parsing messages from the device, and correctly building messages but I have raised this as a draft in the hope that someone can look over it and prod me in the right direction if anything goes wrong.