### PR TITLE
Add support for Cerulean Sonar ROV Locator

### DIFF
--- a/pynmea2/types/talker.py
+++ b/pynmea2/types/talker.py
@@ -1036,3 +1036,25 @@ class ALK(TalkerSentence,SeaTalk):
         ("Data Byte 8", "data_byte8"),
         ("Data Byte 9", "data_byte9")
     )
+
+
+# RTH
+# Used by Cerulean Sonar ROV Locator
+class RTH(TalkerSentence):
+    """
+    RTH
+    """
+    fields = (
+        ("Apparent Bearing to Target in Degrees", "ab", float),
+        ("Apparent Bearing to Target in Compass Degrees", "ac", float),
+        ("Apparent Elevation to Target in Degrees", "ae", float),
+        ("Slant Range in Meters", "sr", float),
+        ("True Bearing to Target in Degrees", "tb", float),
+        ("True Bearing to Target in Compass Degrees", "cb", float),
+        ("True Elevation to Target in Degrees", "te", float),
+        ("Euler Roll", "er", float),
+        ("Euler Pitch", "ep", float),
+        ("Euler Yaw", "ey", float),
+        ("Compass Heading", "ch", float),
+        ("AGC Gain in db", "db", float)
+    )


### PR DESCRIPTION
The [Cerulean Sonar ROV Locator](https://ceruleansonar.com/products/usbl-rov-locator?variant=32099408445506) is an underwater localization system. 

This commit adds our "RTH" message