### PR TITLE
Separate NMEASentence values collection

### DIFF
--- a/pynmea2/nmea.py
+++ b/pynmea2/nmea.py
@@ -179,21 +179,19 @@ class NMEASentence(NMEASentenceBase):
 
     def __repr__(self):
         #pylint: disable=invalid-name
-        r = []
-        d = []
-        t = type(self)
-        for i, v in enumerate(self.data):
-            if i >= len(t.fields):
-                d.append(v)
-                continue
-            name = t.fields[i][1]
-            r.append('%s=%r' % (name, getattr(self, name)))
-
+        d = self.unnamed_values()
         return '<%s(%s)%s>' % (
             type(self).__name__,
-            ', '.join(r),
+            ', '.join('%s=%r' % (n, v) for n, v in self.field_values().items()),
             d and ' data=%r' % d or ''
         )
+
+    def field_values(self):
+        field_names = tuple(map(lambda t: t[1], type(self).fields))
+        return {n: getattr(self, n) for n in field_names[:len(self.data)]}
+
+    def unnamed_values(self):
+        return self.data[len(type(self).fields):]
 
     def identifier(self):
         raise NotImplementedError


### PR DESCRIPTION
Started to work on #107.
Separated the value collection into two methods, one for named values (by `fields`) returning a dict and another one without names returning just a list. Also integrated them into `__repr__`.
Here is how they work currently:

```
msg = pynmea2.parse("$GPGGA,184353.07,1929.045,S,02410.506,E,1,04,2.6,100.00,M,-33.9,M,,0000*6D")
msg.field_values()
Out[9]: 
{'timestamp': datetime.time(18, 43, 53, 70000),
 'lat': '1929.045',
 'lat_dir': 'S',
 'lon': '02410.506',
 'lon_dir': 'E',
 'gps_qual': 1,
 'num_sats': '04',
 'horizontal_dil': '2.6',
 'altitude': 100.0,
 'altitude_units': 'M',
 'geo_sep': '-33.9',
 'geo_sep_units': 'M',
 'age_gps_data': '',
 'ref_station_id': '0000'}
msg.unnamed_values()
Out[10]: []
repr(msg)
Out[11]: "<GGA(timestamp=datetime.time(18, 43, 53, 70000), lat='1929.045', lat_dir='S', lon='02410.506', lon_dir='E', gps_qual=1, num_sats='04', horizontal_dil='2.6', altitude=100.0, altitude_units='M', geo_sep='-33.9', geo_sep_units='M', age_gps_data='', ref_station_id='0000')>"

```

Some points to consider if this solution is already okay:

- [ ] Cast known/named values to their actual types e.g. float?
- [ ] Unit tests