### PR TITLE
Checksum checking + signalId and systemId parsing (NMEA 4.10+ GSV GRS)

### DIFF
--- a/pynmea2/nmea.py
+++ b/pynmea2/nmea.py
@@ -94,8 +94,19 @@ class NMEASentence(NMEASentenceBase):
         Parses a string representing a NMEA 0183 sentence, and returns a
         NMEASentence object
 
-        Raises ValueError if the string could not be parsed, or if the checksum
-        did not match.
+        Parameters
+        ---------
+        line: str
+            The NMEA string to be parsed
+        check: bool
+            If True, checks the checksum.
+
+        Raises
+        ------
+        * ParseError if the string could not be parsed
+        * ChecksumError if the checksum is missing or if 
+          the checksum did not match.
+        * SentenceTypeError if the sentence type is not understood
         '''
         match = NMEASentence.sentence_re.match(line)
         if not match:

--- a/pynmea2/nmea.py
+++ b/pynmea2/nmea.py
@@ -111,7 +111,7 @@ class NMEASentence(NMEASentenceBase):
         if checksum:
             cs1 = int(checksum, 16)
             cs2 = NMEASentence.checksum(nmea_str)
-            if cs1 != cs2:
+            if cs1 != cs2 and check:
                 raise ChecksumError(
                     'checksum does not match: %02X != %02X' % (cs1, cs2), data)
         elif check:

--- a/pynmea2/nmea.py
+++ b/pynmea2/nmea.py
@@ -87,7 +87,7 @@ class NMEASentence(NMEASentenceBase):
         return reduce(operator.xor, map(ord, nmea_str), 0)
 
     @staticmethod
-    def parse(line, check=False, GSV_signal_id=False):
+    def parse(line, check=False, GSV_signal_id=False, GRS_ids=False):
         '''
         parse(line)
 
@@ -101,9 +101,14 @@ class NMEASentence(NMEASentenceBase):
         check: bool
             If True, checks the checksum.
         GSV_signal_id: bool
-            If True, GSV NMEA messages can have signalId appended
-            as in https://www.u-blox.com/en/docs/UBX-18010854.
-
+            If True, assume that GSV NMEA (4.10+) messages have
+            signalId appended as described in
+            https://www.u-blox.com/en/docs/UBX-18010854.
+        GRS_ids: bool
+            If True, assume that GRS NMEA (4.10+) messages have
+            systemId and signalId appended as described in
+            https://www.u-blox.com/en/docs/UBX-18010854.
+        
         Raises
         ------
         * ParseError if the string could not be parsed
@@ -141,6 +146,9 @@ class NMEASentence(NMEASentenceBase):
             if sentence == 'GSV':
                 if GSV_signal_id:
                     cls_kwargs['fields'] = cls.fields[:len(data)-1] + (('GNSS Signal ID', 'signal_id'),)
+            if sentence == 'GRS':
+                if GRS_ids:
+                    cls_kwargs['fields'] = cls.fields + (('GNSS System ID', 'system_id'), ('GNSS Signal ID', 'signal_id'))
             if not cls:
                 # TODO instantiate base type instead of fail
                 raise SentenceTypeError(

--- a/pynmea2/nmea_utils.py
+++ b/pynmea2/nmea_utils.py
@@ -2,6 +2,51 @@
 import datetime
 import re
 
+
+def getattr__(o, name, source='type'):
+    """
+    __getattr__ for the object `o`
+
+    Parameters
+    ---------
+    o: object instance
+        The object intance ("self")
+    name: str
+        The attribute name
+    source: str
+        'type' Uses the `name_to_idx`
+        and `fields` of the type(o).
+        'self' Uses the o.name_to_idx
+        and o.fields instead.
+    """
+    #pylint: disable=invalid-name
+
+    if source == 'type':
+        src = type(o)
+    elif source == 'self':
+        src = o
+    else:
+        raise ValueError('Unknown `source`: '+source)
+    try:
+        i = src.name_to_idx[name]
+    except KeyError:
+        raise AttributeError(name)
+    f = src.fields[i]
+    if i < len(o.data):
+        v = o.data[i]
+    else:
+        v = ''
+    if len(f) >= 3:
+        if v == '':
+            return None
+        try:
+            return f[2](v)
+        except:
+            return v
+    else:
+        return v
+
+
 def valid(s):
     return s == 'A'
 

--- a/pynmea2/types/talker.py
+++ b/pynmea2/types/talker.py
@@ -6,6 +6,7 @@ from ..seatalk_utils import *
 from collections import namedtuple
 from decimal import Decimal
 
+from pynmea2.nmea_utils import getattr__
 
 #pylint: disable=missing-docstring
 #pylint: disable=no-init
@@ -282,6 +283,17 @@ class GSV(TalkerSentence):
         ('SNR 4', 'snr_4'),
     )  # 00-99 dB
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        fields = kwargs.get('fields', None)
+        if fields:
+            self.name_to_idx = dict((f[1], i) for i, f in enumerate(fields))
+            self.fields = fields
+            
+    def __getattr__(self, name):
+        #pylint: disable=invalid-name
+        return getattr__(self, name, 'self')
+  
 
 class HDG(TalkerSentence):
     """ NMEA 0183 standard Heading, Deviation and Variation

--- a/pynmea2/types/talker.py
+++ b/pynmea2/types/talker.py
@@ -8,6 +8,19 @@ from decimal import Decimal
 
 from pynmea2.nmea_utils import getattr__
 
+class TalkerSentenceCustomFields(TalkerSentence):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        fields = kwargs.get('fields', None)
+        if fields:
+            self.name_to_idx = dict((f[1], i) for i, f in enumerate(fields))
+            self.fields = fields
+            
+    def __getattr__(self, name):
+        #pylint: disable=invalid-name
+        return getattr__(self, name, 'self')
+
 #pylint: disable=missing-docstring
 #pylint: disable=no-init
 #pylint: disable=too-few-public-methods
@@ -182,7 +195,7 @@ class GNS(TalkerSentence, LatLonFix):
         ('Differential reference station ID', 'diferential'),
     )
 
-class GRS(TalkerSentence):
+class GRS(TalkerSentenceCustomFields):
     """ Order of satellites will match those in the last GSA
     """
     fields = (
@@ -260,7 +273,7 @@ class GST(TalkerSentence):
     )
 
 
-class GSV(TalkerSentence):
+class GSV(TalkerSentenceCustomFields):
     fields = (
         ('Number of messages of type in cycle', 'num_messages'),
         ('Message Number', 'msg_num'),
@@ -283,16 +296,7 @@ class GSV(TalkerSentence):
         ('SNR 4', 'snr_4'),
     )  # 00-99 dB
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        fields = kwargs.get('fields', None)
-        if fields:
-            self.name_to_idx = dict((f[1], i) for i, f in enumerate(fields))
-            self.fields = fields
-            
-    def __getattr__(self, name):
-        #pylint: disable=invalid-name
-        return getattr__(self, name, 'self')
+
   
 
 class HDG(TalkerSentence):

--- a/test/test_pynmea.py
+++ b/test/test_pynmea.py
@@ -89,7 +89,22 @@ def test_GSV():
     with pytest.raises(pynmea2.ChecksumError):
         # Checksum checks also the signal_id
         pynmea2.parse("$GPGSV,3,3,11,26,49,301,08,29,58,056,37,31,50,235,22,123*55", GSV_signal_id=True, check=True)
-    
+
+def test_GRS():
+
+    # Test GRS message with systemId and signalId
+    data = "$GNGRS,121519.00,1,0.2,-1.4,-1.9,3.0,-0.2,1.2,-0.8,-1.2,,,,,3,7*70"
+    # There should be no signal_id when not asked.
+    msg = pynmea2.parse(data, GRS_ids=False)
+    assert not hasattr(msg, 'system_id')
+    assert not hasattr(msg, 'signal_id')
+
+    # There should be signal_id when asked.
+    msg = pynmea2.parse(data, GRS_ids=True)
+    assert msg.system_id == '3'
+    assert msg.signal_id == '7'
+
+
 
 def test_dollar():
     data = 'GPGSV,3,3,09,24,03,046,*47\r\n'

--- a/test/test_pynmea.py
+++ b/test/test_pynmea.py
@@ -20,7 +20,7 @@ def test_sentence():
 def test_checksum():
     d = data[:-2] + '00'
     with pytest.raises(pynmea2.ChecksumError):
-        msg = pynmea2.parse(d)
+        msg = pynmea2.parse(d, check=True)
 
 
 def test_attribute():

--- a/test/test_pynmea.py
+++ b/test/test_pynmea.py
@@ -71,6 +71,26 @@ def test_missing_4():
     assert msg.render() == data
 
 
+def test_GSV():
+
+    # Test a shorter GSV message
+    data = "$GPGSV,3,3,09,25,,,40,1*6E"
+    # There should be no signal_id when not asked.
+    msg = pynmea2.parse(data)
+    assert not hasattr(msg, 'signal_id')
+
+    # There should be signal_id when asked.
+    msg = pynmea2.parse(data, GSV_signal_id=True)
+    assert msg.signal_id == '1'
+    assert not hasattr(msg, 'sv_prn_num_2')
+
+    # OK checksum (signal_id included); no errors
+    pynmea2.parse("$GPGSV,3,3,11,26,49,301,08,29,58,056,37,31,50,235,22,1*55", GSV_signal_id=True, check=True)
+    with pytest.raises(pynmea2.ChecksumError):
+        # Checksum checks also the signal_id
+        pynmea2.parse("$GPGSV,3,3,11,26,49,301,08,29,58,056,37,31,50,235,22,123*55", GSV_signal_id=True, check=True)
+    
+
 def test_dollar():
     data = 'GPGSV,3,3,09,24,03,046,*47\r\n'
     msg = pynmea2.parse(data)


### PR DESCRIPTION
The checksum checking was previously always on, even though the default value for `check` in `parse()` was `False`