### PR TITLE
NMEASentence/__getattr__: Graceful fail

### DIFF
--- a/pynmea2/nmea.py
+++ b/pynmea2/nmea.py
@@ -1,6 +1,10 @@
 import re
 import operator
 from functools import reduce
+from logging import getLogger
+
+
+log = getLogger()
 
 
 class ParseError(ValueError):
@@ -149,10 +153,12 @@ class NMEASentence(NMEASentenceBase):
     def __getattr__(self, name):
         #pylint: disable=invalid-name
         t = type(self)
-        try:
-            i = t.name_to_idx[name]
-        except KeyError:
-            raise AttributeError(name)
+
+        if name not in t.name_to_idx:
+            log.debug("%s has no attribute %s", self.__class__.__name__, name)
+            return None
+        i = t.name_to_idx[name]
+
         f = t.fields[i]
         if i < len(self.data):
             v = self.data[i]

--- a/test/test_pynmea.py
+++ b/test/test_pynmea.py
@@ -25,8 +25,7 @@ def test_checksum():
 
 def test_attribute():
     msg = pynmea2.parse(data)
-    with pytest.raises(AttributeError):
-        msg.foobar
+    assert msg.foobar is None
 
 
 def test_fail():


### PR DESCRIPTION
** Return None and handle the error without raising an error. Technically
raising an error after catching another is bad as it still creates a stack
trace (causing a hard failure) and it demolishes the original stack. Here the
return None is handled and a message is logged in debug format. The other way
to resolve this on a hard failure is to reraise the origin after logging just call
raise to preserve the stack.

** Altered the test that utilized this code.

Fix for #94