### PR TITLE
Adds support for $PFLAA and $PFLA…  …U traffic sentences from the FLARM protocol: http://delta-omega.com/download/EDIA/FLARM_DataportManual_v3.02E.pdf

### DIFF
--- a/pynmea2/types/talker.py
+++ b/pynmea2/types/talker.py
@@ -1038,3 +1038,35 @@ class ALK(TalkerSentence,SeaTalk):
         ("Data Byte 8", "data_byte8"),
         ("Data Byte 9", "data_byte9")
     )
+
+# Implemented by Davis Chappins for FLARM traffic
+#PFLAU: Operating status and priority intruder and obstacle data 
+class LAU(TalkerSentence):
+    fields = (
+        ("RX","RX"),
+        ("TX","TX"),  
+        ("GPS","GPS"),
+        ("Power","Power"),
+        ("AlarmLevel","AlarmLevel"),
+        ("RelativeBearing","RelativeBearing"),
+        ("AlarmType","AlarmType"),
+        ("RelativeVertial","RelativeVertical"),
+        ("RelativeDistance","RelativeDistance"),
+        
+    )
+
+#PFLAA: Data on other moving objects around 
+class LAA(TalkerSentence):
+    fields = (
+        ("AlarmLevel","AlarmLevel"),
+        ("RelativeNorth","RelativeNorth"),
+        ("RelativeEast","RelativeEast"),
+        ("RelativeVertical","RelativeVertical"),
+        ("ID-Type","ID-Type"),
+        ("ID","ID"),
+        ("Track","Track"),
+        ("TurnRate","TurnRate"),
+        ("GroundSpeed","GroundSpeed"),
+        ("ClimbRate","ClimbRate"),
+        ("Type","Type"),
+    )


### PR DESCRIPTION
Adds the two small classes from Davis Chappins for FLARM traffic on top of master pynmea2

Tested with Davis Chappins  script, setup according to procedure: 
https://aeroplaying.uk/I/+/GDL90toNMEA/


Original code: 
https://github.com/DavisChappins/pynmea2 

This merged support for $PFLAA and $PFLAU traffic sentences from the FLARM protocol
https://github.com/nrbray/pynmea2/commit/29b0ad7ec1136d35c278a07976523943d9d6e810

Background documentation for the changes:
http://delta-omega.com/download/EDIA/FLARM_DataportManual_v3.02E.pdf

