### PR TITLE
Python 3.12 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # python-version: ["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-
-# What works:
-#  macos 3.8-3.11
-#  ubuntu 3.8-3.11
-
-
-      #  exclude:
-      #   - os: macos-latest
-      #     python-version: "3.9"
-      #   - os: windows-latest
-      #     python-version: "3.9"
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -39,7 +27,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install pytest
         python -m pip install flake8
-        python -m pip install wheel
+        python -m pip install setuptools wheel
         python -m pip install importlib_metadata
     - name: Lint with flake8
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 name: pynmea2
 on:
   push:
-    branches: ["master", "py3v12-compatability"]
+    branches: ["master"]
   pull_request:
     branches: ["master"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,30 +4,23 @@
 name: pynmea2
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "py3v12-compatability"]
   pull_request:
     branches: ["master"]
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-       python: ["3"]
-       os: ["ubuntu-latest"]
-       include:
-          - {python: "3.8", os: "ubuntu-22.04"}
-          - {python: "3.9", os: "ubuntu-22.04"}
-          - {python: "3.10", os: "ubuntu-22.04"}
-          - {python: "3.11", os: "ubuntu-22.04"}
-          - {python: "3.12", os: "ubuntu-22.04"}
+       python-version: ["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python }}
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,24 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-       python-version: ["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        # python-version: ["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+# What works:
+#  macos 3.8-3.11
+#  ubuntu 3.8-3.11
+
+
+      #  exclude:
+      #   - os: macos-latest
+      #     python-version: "3.9"
+      #   - os: windows-latest
+      #     python-version: "3.9"
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -26,6 +39,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install pytest
         python -m pip install flake8
+        python -m pip install wheel
         python -m pip install importlib_metadata
     - name: Lint with flake8
       run: |
@@ -35,7 +49,7 @@ jobs:
     - name: Build and test
       run: |
         python setup.py sdist --formats=zip
-        pip install dist/pynmea2*.zip
+        pip install --find-links=./dist --no-index --no-build-isolation pynmea2
         pytest
     - name: Coveralls
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - {python: "3.9", os: "ubuntu-22.04"}
           - {python: "3.10", os: "ubuntu-22.04"}
           - {python: "3.11", os: "ubuntu-22.04"}
+          - {python: "3.12", os: "ubuntu-22.04"}
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python }}

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-pynmea2
-=======
+# pynmea2
 
 `pynmea2` is a python library for the [NMEA 0183](http://en.wikipedia.org/wiki/NMEA_0183) protocol
 
 `pynmea2` is based on [`pynmea`](https://code.google.com/p/pynmea/) by Becky Lewis
 
-The `pynmea2` homepage is located at http://github.com/Knio/pynmea2
+The `pynmea2` homepage is located at <http://github.com/Knio/pynmea2>
 
- ### Compatibility
+## Compatibility
 
 `pynmea2` is compatable with Python 2.7 and Python 3.4+
 
@@ -15,18 +14,19 @@ The `pynmea2` homepage is located at http://github.com/Knio/pynmea2
 [![Build status](https://github.com/Knio/pynmea2/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Knio/pynmea2/actions/workflows/ci.yml?query=branch%3Amaster+)
 [![Coverage status](https://img.shields.io/coveralls/github/Knio/pynmea2/master.svg?style=flat)](https://coveralls.io/r/Knio/pynmea2?branch=master)
 
-### Installation
+## Installation
 
 The recommended way to install `pynmea2` is with
 [pip](http://pypi.python.org/pypi/pip/):
 
-    pip install pynmea2
+```bash
+pip install pynmea2
+```
 
 [![PyPI version](https://img.shields.io/pypi/v/pynmea2.svg?style=flat)](https://pypi.org/project/pynmea2/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/pynmea2.svg?style=flat)](https://pypi.org/project/pynmea2/)
 
-Parsing
--------
+## Parsing
 
 You can parse individual NMEA sentences using the `parse(data, check=False)` function, which takes a string containing a
 NMEA 0183 sentence and returns a `NMEASentence` object. Note that the leading '$' is optional and trailing whitespace is ignored when parsing a sentence.
@@ -91,8 +91,7 @@ For example, `latitude` and `longitude` properties exist as helpers to access th
 "-19°29′02.7000″"
 ```
 
-Generating
-----------
+## Generating
 
 You can create a `NMEASentence` object by calling the constructor with talker, message type, and data fields:
 
@@ -101,7 +100,6 @@ You can create a `NMEASentence` object by calling the constructor with talker, m
 >>> msg = pynmea2.GGA('GP', 'GGA', ('184353.07', '1929.045', 'S', '02410.506', 'E', '1', '04', '2.6', '100.00', 'M', '-33.9', 'M', '', '0000'))
 ```
 
-
 and generate a NMEA string from a `NMEASentence` object:
 
 ```python
@@ -109,9 +107,7 @@ and generate a NMEA string from a `NMEASentence` object:
 '$GPGGA,184353.07,1929.045,S,02410.506,E,1,04,2.6,100.00,M,-33.9,M,,0000*6D'
 ```
 
-
-File reading example
---------
+## File reading example
 
 See [examples/read_file.py](/examples/read_file.py)
 
@@ -129,9 +125,7 @@ for line in file.readlines():
         continue
 ```
 
-
-pySerial device example
----------
+## `pySerial` device example
 
 See [examples/read_serial.py](/examples/read_serial.py)
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,26 @@
+import importlib.machinery
+import importlib.util
+
 from setuptools import setup
 
-import imp
-_version = imp.load_source("pynmea2._version", "pynmea2/_version.py")
+
+def load_source(modname, filename):
+    """Load a source file and return its module object.
+
+    From: https://docs.python.org/3.12/whatsnew/3.12.html#imp
+    """
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(
+        modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
+
+
+_version = load_source("pynmea2._version", "pynmea2/_version.py")
 
 setup(
     name='pynmea2',
@@ -12,7 +31,7 @@ setup(
     url='https://github.com/Knio/pynmea2',
 
     description='Python library for the NMEA 0183 protcol',
-    packages=['pynmea2','pynmea2.types','pynmea2.types.proprietary'],
+    packages=['pynmea2', 'pynmea2.types', 'pynmea2.types.proprietary'],
     keywords='python nmea gps parse parsing nmea0183 0183',
 
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -10,15 +10,13 @@ def load_source(modname, filename):
     From: https://docs.python.org/3.12/whatsnew/3.12.html#imp
     """
     loader = importlib.machinery.SourceFileLoader(modname, filename)
-    spec = importlib.util.spec_from_file_location(
-        modname, filename, loader=loader)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
     module = importlib.util.module_from_spec(spec)
     # The module is always executed and not cached in sys.modules.
     # Uncomment the following line to cache the module.
     # sys.modules[module.__name__] = module
     loader.exec_module(module)
     return module
-
 
 _version = load_source("pynmea2._version", "pynmea2/_version.py")
 
@@ -31,7 +29,7 @@ setup(
     url='https://github.com/Knio/pynmea2',
 
     description='Python library for the NMEA 0183 protcol',
-    packages=['pynmea2', 'pynmea2.types', 'pynmea2.types.proprietary'],
+    packages=['pynmea2','pynmea2.types','pynmea2.types.proprietary'],
     keywords='python nmea gps parse parsing nmea0183 0183',
 
     classifiers=[
@@ -48,6 +46,9 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Scientific/Engineering :: GIS',
         'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
Removed dependency on `imp` which is depreciated and removed in Python 3.12.  Replaced with `importlib` as suggested in the issue below (https://docs.python.org/3.12/whatsnew/3.12.html#imp).

Install tested OK on 3.12 and 3.11.

Closes #163 