### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
         - os: macos-latest
-          python-version:: "3.8"
+          python-version: "3.8"
         - os: macos-latest
-          python-version:: "3.9"
+          python-version: "3.9"
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Python 3.8 and 3.9 are since this week not available on `macos-latest` since they switched to `arm64` (https://github.com/actions/setup-python/issues/850)