### PR TITLE
Add support for MTA sentence

### DIFF
--- a/pynmea2/types/talker.py
+++ b/pynmea2/types/talker.py
@@ -559,6 +559,13 @@ class ZDA(TalkerSentence, DatetimeFix):
         return d.astimezone(self.tzinfo)
 
 
+class MTA(TalkerSentence):
+    """ Air Temperature (to be phased out)
+    """
+    fields = (
+        ("Air temperature", "temperature", Decimal),
+        ("Units of measurement", "units"),
+    )
 
 
 # Implemented by Janez Stupar for Visionect
@@ -881,12 +888,6 @@ class TTM(TalkerSentence):
 
 #class LCD(TalkerSentence):
 #    """ Loran-C Signal Data
-#    """
-    #    fields = (
-    # )
-
-#class MTA(TalkerSentence):
-#    """ Air Temperature (to be phased out)
 #    """
     #    fields = (
     # )

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -341,3 +341,13 @@ def test_HEV():
     assert msg.talker == "GP"
     assert msg.sentence_type == "HEV"
     assert msg.heave == -0.01
+
+
+def test_MTA():
+    data = "$WIMTA,010.0,C*2A"
+    msg = pynmea2.parse(data)
+    assert msg.render() == data
+    assert msg.talker == 'WI'
+    assert msg.sentence_type == 'MTA'
+    assert msg.temperature == 10.0
+    assert msg.units == 'C'


### PR DESCRIPTION
We do work for the Yachting industry and deal with a lot of NMEA devices.
As part of our internal goal to centralize parsing, we decided to move all our parsing to pynmea2 and contribute back the sentences we come across in the field, starting with MTA.
I see that there were plans to phase this one out, but we still see it's being used by devices in the wild.