### PR TITLE
Parse fractional seconds exactly in timestamp() (fix off-by-one microseconds)

### DIFF
--- a/pynmea2/nmea_utils.py
+++ b/pynmea2/nmea_utils.py
@@ -23,7 +23,13 @@ def timestamp(s):
     datetime.time object
     '''
     ms_s = s[6:]
-    ms = ms_s and int(float(ms_s) * 1000000) or 0
+    if ms_s.startswith('.'):
+        # Parse the fractional seconds as an exact integer count of
+        # microseconds. Going through float() truncates inexactly, e.g.
+        # int(float('.00397') * 1000000) == 3969 instead of 3970.
+        ms = int((ms_s[1:] + '000000')[:6])
+    else:
+        ms = 0
 
     t = datetime.time(
         hour=int(s[0:2]),

--- a/test/test_pynmea.py
+++ b/test/test_pynmea.py
@@ -127,6 +127,35 @@ def test_timestamp():
     assert pynmea2.nmea_utils.timestamp('115919.1234567').microsecond == 123456
 
 
+def test_timestamp_fractional_seconds_exact():
+    ts = pynmea2.nmea_utils.timestamp
+    # Fractional seconds with up to 6 digits are exactly representable in
+    # microseconds and must not be truncated through a binary float:
+    # int(float('.00397') * 1000000) == 3969, but .00397 s is exactly 3970 us.
+    assert ts('120000.00397').microsecond == 3970
+    assert ts('120000.00399').microsecond == 3990
+    assert ts('120000.00785').microsecond == 7850
+
+    # Every 5-digit fraction must round-trip exactly (1153 of these were
+    # previously off by one microsecond).
+    for i in range(0, 100000):
+        assert ts('120000.%05d' % i).microsecond == i * 10
+
+    # More than 6 fractional digits are truncated (not rounded), and the
+    # result never overflows datetime's 0..999999 microsecond range.
+    assert ts('120000.1234567').microsecond == 123456
+    assert ts('120000.9999999').microsecond == 999999
+
+    # A timestamp without a fractional part has zero microseconds.
+    assert ts('120000').microsecond == 0
+
+    # The fix also applies through the public parse() entry point.
+    msg = pynmea2.parse(
+        '$GPGGA,181032.00397,3926.276,N,07739.361,W,0,00,,,M,,M,,*5F',
+        checksums='my_data_is_corrupt')
+    assert msg.timestamp.microsecond == 3970
+
+
 def test_corrupt_message():
     # checksum= parameter acts as intended
     valid_checksum =    '$CCGPQ,GGA*2B'


### PR DESCRIPTION
### The bug

`nmea_utils.timestamp()` converts the fractional seconds of a sentence time through a binary float, which truncates and yields microseconds that are off by one for ~1.15% of inputs:

```python
>>> from pynmea2.nmea_utils import timestamp
>>> timestamp('120000.00397').microsecond
3969          # expected 3970  (.00397 s == 3.97 ms == exactly 3970 us)
>>> timestamp('120000.00399').microsecond
3989          # expected 3990
```

`timestamp()` is the library's central time parser, so this reaches every sentence that carries a time (GGA/RMC/GLL/ZDA/…) via `parse()`:

```python
>>> import pynmea2
>>> pynmea2.parse('$GPGGA,181032.00397,3926.276,N,07739.361,W,0,00,,,M,,M,,*5F',
...               checksums='my_data_is_corrupt').timestamp.microsecond
3969          # expected 3970
```

A sweep of all 100000 five-digit fractions finds **1153 systematically wrong**, always exactly 1 µs low.

### Why the expected value is unambiguous

`microsecond` is an integer field, and a fractional second with ≤6 digits is exactly representable at microsecond resolution — `.00397 s` is exactly `3970 µs`. The existing `test_timestamp` already asserts exact values (`.123456`→123456, `.1234`→123400) and `test_nor` asserts `.3341`→334100; it simply never picked a float-unsafe fraction, so it missed this.

### Root cause

`pynmea2/nmea_utils.py`:

```python
ms = ms_s and int(float(ms_s) * 1000000) or 0
```

Binary floats can't represent most decimal fractions exactly; `float('.00397') * 1000000` is `3969.9999999…`, and `int()` truncates downward → off by one. (A naive `round()` "fix" is also wrong: `round(0.9999995 * 1e6) == 1000000`, which `datetime.time(...)` rejects with `microsecond must be in 0..999999`.)

### The fix

Parse the fractional digits as an integer, right-padded/truncated to 6-digit microsecond resolution — exact, and inherently overflow-safe:

```python
if ms_s.startswith('.'):
    ms = int((ms_s[1:] + '000000')[:6])
else:
    ms = 0
```

### Tests

`test_timestamp_fractional_seconds_exact`: the known-bad values, an exhaustive sweep asserting every 5-digit fraction `i` gives `i*10` µs, the >6-digit truncation and the `.9999999`→`999999` no-overflow boundary, the no-fraction case, and the public `parse()` entry point. The new test fails on `master` (`assert 3969 == 3970`) and passes with the fix; the full suite stays green (106 passed), and all pre-existing `timestamp` assertions (incl. the 7-digit truncation case and `test_nor`) are preserved.
